### PR TITLE
Fix login and user-specific data

### DIFF
--- a/src/main/java/controller/CategoryController.java
+++ b/src/main/java/controller/CategoryController.java
@@ -1,16 +1,22 @@
 package controller;
 
 import dao.CategoryDAO;
+import dao.UserDAO;
 import model.Category;
+import model.User;
 
 import java.util.List;
 
 public class CategoryController {
 
     private final CategoryDAO categoryDAO;
+    private final UserDAO userDAO;
+    private final int userId;
 
-    public CategoryController() {
+    public CategoryController(int userId) {
         this.categoryDAO = new CategoryDAO();
+        this.userDAO = new UserDAO();
+        this.userId = userId;
     }
 
     /**
@@ -25,12 +31,12 @@ public class CategoryController {
             throw new IllegalArgumentException("Nome da categoria é obrigatório");
         }
 
-        List<Category> existing = categoryDAO.findAll();
+        List<Category> existing = categoryDAO.findAll(userId);
         if (existing.stream().anyMatch(c -> c.getName().equalsIgnoreCase(name))) {
             throw new IllegalArgumentException("Categoria já existe");
         }
-
-        Category newCategory = new Category(name, description);
+        User user = userDAO.findById(userId);
+        Category newCategory = new Category(name, description, user);
         categoryDAO.save(newCategory);
         return newCategory;
     }
@@ -44,7 +50,7 @@ public class CategoryController {
      * @return Categoria atualizada
      */
     public Category updateCategory(int categoryId, String newName, String newDescription) {
-        Category category = categoryDAO.findById(categoryId);
+        Category category = categoryDAO.findById(categoryId, userId);
 
         if (category == null) {
             throw new IllegalArgumentException("Categoria não encontrada");
@@ -69,7 +75,7 @@ public class CategoryController {
      * @return true se removido
      */
     public boolean removeCategory(int categoryId) {
-        Category category = categoryDAO.findById(categoryId);
+        Category category = categoryDAO.findById(categoryId, userId);
         if (category != null) {
             categoryDAO.delete(category);
             return true;
@@ -81,7 +87,7 @@ public class CategoryController {
      * Retorna todas as categorias do sistema.
      */
     public List<Category> getAllCategories() {
-        return categoryDAO.findAll();
+        return categoryDAO.findAll(userId);
     }
 
     /**
@@ -91,6 +97,6 @@ public class CategoryController {
      * @return Categoria correspondente ou null
      */
     public Category getCategoryById(int categoryId) {
-        return categoryDAO.findById(categoryId);
+        return categoryDAO.findById(categoryId, userId);
     }
 }

--- a/src/main/java/controller/DashboardController.java
+++ b/src/main/java/controller/DashboardController.java
@@ -12,8 +12,8 @@ import java.util.stream.Collectors;
 public class DashboardController {
     private final TransactionController transactionController;
 
-    public DashboardController() {
-        this.transactionController = new TransactionController();
+    public DashboardController(int userId) {
+        this.transactionController = new TransactionController(userId);
     }
 
     /**

--- a/src/main/java/controller/TransactionController.java
+++ b/src/main/java/controller/TransactionController.java
@@ -2,8 +2,10 @@ package controller;
 
 import dao.CategoryDAO;
 import dao.TransactionDAO;
+import dao.UserDAO;
 import model.Transaction;
 import model.Category;
+import model.User;
 
 import java.util.Date;
 import java.util.List;
@@ -12,10 +14,14 @@ public class TransactionController {
 
     private final TransactionDAO transactionDAO;
     private final CategoryDAO categoryDAO;
+    private final UserDAO userDAO;
+    private final int userId;
 
-    public TransactionController() {
+    public TransactionController(int userId) {
         this.transactionDAO = new TransactionDAO();
         this.categoryDAO = new CategoryDAO();
+        this.userDAO = new UserDAO();
+        this.userId = userId;
     }
 
     /**
@@ -39,7 +45,8 @@ public class TransactionController {
             date = new Date();
         }
 
-        Transaction transaction = new Transaction(type, amount, category, date, description);
+        User user = userDAO.findById(userId);
+        Transaction transaction = new Transaction(type, amount, category, user, date, description);
         transactionDAO.save(transaction);
         return transaction;
     }
@@ -48,7 +55,7 @@ public class TransactionController {
      * Retorna todas as transações do sistema.
      */
     public List<Transaction> getAllTransactions() {
-        return transactionDAO.findAll();
+        return transactionDAO.findAll(userId);
     }
 
     /**
@@ -56,7 +63,7 @@ public class TransactionController {
      */
     public List<Transaction> getTransactions(Date startDate, Date endDate,
                                              Transaction.Type type, Category category) {
-        List<Transaction> filtered = transactionDAO.findByDateRange(startDate, endDate);
+        List<Transaction> filtered = transactionDAO.findByDateRange(startDate, endDate, userId);
 
         return filtered.stream()
                 .filter(t -> type == null || t.getType() == type)
@@ -68,7 +75,7 @@ public class TransactionController {
      * Retorna todas as categorias cadastradas.
      */
     public List<Category> getAllCategories() {
-        return categoryDAO.findAll();
+        return categoryDAO.findAll(userId);
     }
 
     /**
@@ -82,13 +89,13 @@ public class TransactionController {
      * Retorna o total de receitas.
      */
     public double getTotalIncome() {
-        return transactionDAO.sumByType(Transaction.Type.INCOME);
+        return transactionDAO.sumByType(Transaction.Type.INCOME, userId);
     }
 
     /**
      * Retorna o total de despesas.
      */
     public double getTotalExpense() {
-        return transactionDAO.sumByType(Transaction.Type.EXPENSE);
+        return transactionDAO.sumByType(Transaction.Type.EXPENSE, userId);
     }
 }

--- a/src/main/java/dao/CategoryDAO.java
+++ b/src/main/java/dao/CategoryDAO.java
@@ -22,15 +22,22 @@ public class CategoryDAO {
         }
     }
 
-    public List<Category> findAll() {
+    public List<Category> findAll(int userId) {
         try (Session session = HibernateUtil.getSessionFactory().openSession()) {
-            return session.createQuery("FROM Category", Category.class).list();
+            Query<Category> query = session.createQuery(
+                    "FROM Category WHERE user.id = :userId", Category.class);
+            query.setParameter("userId", userId);
+            return query.list();
         }
     }
 
-    public Category findById(int id) {
+    public Category findById(int id, int userId) {
         try (Session session = HibernateUtil.getSessionFactory().openSession()) {
-            return session.get(Category.class, id);
+            Query<Category> query = session.createQuery(
+                    "FROM Category WHERE id = :id AND user.id = :userId", Category.class);
+            query.setParameter("id", id);
+            query.setParameter("userId", userId);
+            return query.uniqueResult();
         }
     }
 

--- a/src/main/java/dao/TransactionDAO.java
+++ b/src/main/java/dao/TransactionDAO.java
@@ -23,34 +23,41 @@ public class TransactionDAO {
         }
     }
 
-    public List<Transaction> findAll() {
+    public List<Transaction> findAll(int userId) {
         try (Session session = HibernateUtil.getSessionFactory().openSession()) {
-            return session.createQuery("FROM Transaction", Transaction.class).list();
-        }
-    }
-
-    public List<Transaction> findByType(Type type) {
-        try (Session session = HibernateUtil.getSessionFactory().openSession()) {
-            Query<Transaction> query = session.createQuery("FROM Transaction WHERE type = :type", Transaction.class);
-            query.setParameter("type", type);
+            Query<Transaction> query = session.createQuery(
+                    "FROM Transaction WHERE user.id = :userId", Transaction.class);
+            query.setParameter("userId", userId);
             return query.list();
         }
     }
 
-    public List<Transaction> findByDateRange(Date startDate, Date endDate) {
+    public List<Transaction> findByType(Type type, int userId) {
         try (Session session = HibernateUtil.getSessionFactory().openSession()) {
             Query<Transaction> query = session.createQuery(
-                    "FROM Transaction WHERE date BETWEEN :start AND :end", Transaction.class);
+                    "FROM Transaction WHERE user.id = :userId AND type = :type", Transaction.class);
+            query.setParameter("type", type);
+            query.setParameter("userId", userId);
+            return query.list();
+        }
+    }
+
+    public List<Transaction> findByDateRange(Date startDate, Date endDate, int userId) {
+        try (Session session = HibernateUtil.getSessionFactory().openSession()) {
+            Query<Transaction> query = session.createQuery(
+                    "FROM Transaction WHERE user.id = :userId AND date BETWEEN :start AND :end", Transaction.class);
+            query.setParameter("userId", userId);
             query.setParameter("start", startDate);
             query.setParameter("end", endDate);
             return query.list();
         }
     }
 
-    public double sumByType(Type type) {
+    public double sumByType(Type type, int userId) {
         try (Session session = HibernateUtil.getSessionFactory().openSession()) {
             Query<Double> query = session.createQuery(
-                    "SELECT SUM(amount) FROM Transaction WHERE type = :type", Double.class);
+                    "SELECT SUM(amount) FROM Transaction WHERE user.id = :userId AND type = :type", Double.class);
+            query.setParameter("userId", userId);
             query.setParameter("type", type);
             Double result = query.uniqueResult();
             return result != null ? result : 0.0;

--- a/src/main/java/dao/UserDAO.java
+++ b/src/main/java/dao/UserDAO.java
@@ -24,7 +24,16 @@ public class UserDAO {
 
     public User findByEmail(String email) {
         try (Session session = HibernateUtil.getSessionFactory().openSession()) {
-            return session.get(User.class, 1); // apenas teste
+            Query<User> query = session.createQuery(
+                    "FROM User WHERE email = :email", User.class);
+            query.setParameter("email", email);
+            return query.uniqueResult();
+        }
+    }
+
+    public User findById(int id) {
+        try (Session session = HibernateUtil.getSessionFactory().openSession()) {
+            return session.get(User.class, id);
         }
     }
 

--- a/src/main/java/model/Category.java
+++ b/src/main/java/model/Category.java
@@ -1,6 +1,7 @@
 package model;
 
 import jakarta.persistence.*;
+import model.User;
 
 @Entity
 @Table(name = "categories")
@@ -12,14 +13,19 @@ public class Category {
 
     private String name;
     private String description;
+    
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "user_id")
+    private User user;
 
     public Category() {
         // Construtor vazio obrigatório para JPA
     }
 
-    public Category(String name, String description) {
+    public Category(String name, String description, User user) {
         this.name = name;
         this.description = description;
+        this.user = user;
     }
 
     public int getId() {
@@ -34,12 +40,20 @@ public class Category {
         return description;
     }
 
+    public User getUser() {
+        return user;
+    }
+
     public void setName(String name) {
         this.name = name;
     }
 
     public void setDescription(String description) {
         this.description = description;
+    }
+
+    public void setUser(User user) {
+        this.user = user;
     }
 
     @Override

--- a/src/main/java/model/Transaction.java
+++ b/src/main/java/model/Transaction.java
@@ -1,6 +1,7 @@
 package model;
 
 import jakarta.persistence.*;
+import model.User;
 import java.util.Date;
 
 @Entity
@@ -24,6 +25,10 @@ public class Transaction {
     @JoinColumn(name = "category_id")
     private Category category;
 
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "user_id")
+    private User user;
+
     @Temporal(TemporalType.DATE)
     private Date date;
 
@@ -33,10 +38,11 @@ public class Transaction {
         // Construtor vazio obrigatório para Hibernate
     }
 
-    public Transaction(Type type, double amount, Category category, Date date, String description) {
+    public Transaction(Type type, double amount, Category category, User user, Date date, String description) {
         this.type = type;
         this.amount = amount;
         this.category = category;
+        this.user = user;
         this.date = date != null ? date : new Date();
         this.description = description;
     }
@@ -57,6 +63,10 @@ public class Transaction {
         return category;
     }
 
+    public User getUser() {
+        return user;
+    }
+
     public Date getDate() {
         return date;
     }
@@ -75,6 +85,10 @@ public class Transaction {
 
     public void setCategory(Category category) {
         this.category = category;
+    }
+
+    public void setUser(User user) {
+        this.user = user;
     }
 
     public void setDate(Date date) {

--- a/src/main/java/view/CategoryView.java
+++ b/src/main/java/view/CategoryView.java
@@ -10,13 +10,15 @@ import java.util.List;
 
 public class CategoryView extends JPanel {
     private CategoryController controller;
+    private final int userId;
     private JTable categoryTable;
     private DefaultTableModel tableModel;
     private JTextField nameField;
     private JTextArea descriptionArea;
 
-    public CategoryView() {
-        this.controller = new CategoryController();
+    public CategoryView(int userId) {
+        this.userId = userId;
+        this.controller = new CategoryController(userId);
         initializeUI();
     }
 

--- a/src/main/java/view/DashboardView.java
+++ b/src/main/java/view/DashboardView.java
@@ -29,9 +29,12 @@ public class DashboardView extends JPanel {
     private CategoryComboBox categoryFilterComboBox;
     private JButton filterButton;
 
-    public DashboardView() {
-        this.controller = new DashboardController();
-        this.categoryController = new CategoryController();
+    private final int userId;
+
+    public DashboardView(int userId) {
+        this.userId = userId;
+        this.controller = new DashboardController(userId);
+        this.categoryController = new CategoryController(userId);
         initializeUI();
         updateData();
     }

--- a/src/main/java/view/MainView.java
+++ b/src/main/java/view/MainView.java
@@ -29,9 +29,9 @@ public class MainView extends JFrame {
 
         tabbedPane = new JTabbedPane();
 
-        DashboardView dashboardView = new DashboardView();
-        TransactionView transactionView = new TransactionView();
-        CategoryView categoryView = new CategoryView();
+        DashboardView dashboardView = new DashboardView(userId);
+        TransactionView transactionView = new TransactionView(userId);
+        CategoryView categoryView = new CategoryView(userId);
 
         tabbedPane.addTab("Dashboard", dashboardView);
         tabbedPane.addTab("Transações", transactionView);

--- a/src/main/java/view/TransactionView.java
+++ b/src/main/java/view/TransactionView.java
@@ -17,6 +17,7 @@ import java.util.List;
 
 public class TransactionView extends JPanel {
     private TransactionController controller;
+    private final int userId;
     private JComboBox<String> typeComboBox;
     private JTextField amountField;
     private JComboBox<Category> categoryComboBox;
@@ -26,8 +27,9 @@ public class TransactionView extends JPanel {
     private TransactionTable transactionTable;
     private DefaultTableModel tableModel;
 
-    public TransactionView() {
-        this.controller = new TransactionController();
+    public TransactionView(int userId) {
+        this.userId = userId;
+        this.controller = new TransactionController(userId);
         initializeUI();
     }
 


### PR DESCRIPTION
## Summary
- use email when finding users in `UserDAO`
- associate `Category` and `Transaction` entities with `User`
- update DAOs to query by user ID
- pass user ID through controllers and views so each user sees only their own data

## Testing
- `mvn -q -DskipTests=true package` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6841d00ae0dc832fbe0b40b226ad181c